### PR TITLE
Feature/block guest checkout subscription

### DIFF
--- a/admin/language/en-GB/en-GB.com_phocacart.ini
+++ b/admin/language/en-GB/en-GB.com_phocacart.ini
@@ -16,6 +16,8 @@ COM_PHOCACART_ORDER_PAYMENT_PROCESSED_ADDITIONAL_INFO=""
 COM_PHOCACART_ORDER_PAYMENT_PROCESSED_DOWNLOADABLE_ITEMS_ADDITIONAL_INFO=""
 COM_PHOCACART_ORDER_PAYMENT_CANCELED_ADDITIONAL_INFO=""
 
+;[6.1.4]
+COM_PHOCACART_ERROR_GUEST_CHECKOUT_NOT_ALLOWED_SUBSCRIPTION="Your cart contains a subscription product, which requires a registered account. Please log in or register to continue, or remove the subscription item from your cart to check out as a guest."
 
 ;[6.1.3]
 COM_PHOCACART_FOSS_DECLARATION="<h3>Free and Open Source Software (FOSS) Declaration</h3>"

--- a/admin/libraries/phocacart/cart/cart.php
+++ b/admin/libraries/phocacart/cart/cart.php
@@ -939,6 +939,33 @@ class PhocacartCart
         return $this->fullitems;
     }
 
+ /**
+     * Check whether the cart currently contains at least one subscription
+     * product (product type = 6).
+     *
+     * Used to prevent guest checkout for subscription purchases, since a
+     * subscription must be tied to a registered user account.
+     *
+     * @return bool
+     *
+     * @since 6.2.0
+     */
+    public function hasSubscriptionProduct(): bool {
+
+        if (empty($this->fullitems[0])) {
+            return false;
+        }
+
+        foreach ($this->fullitems[0] as $item) {
+            // Items are stored as plain arrays (idkey => array), not objects
+            if (isset($item['type']) && (int) $item['type'] === 6) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    
     public function getCoupon() {
 
         $coupon          = array();

--- a/site/controllers/checkout.php
+++ b/site/controllers/checkout.php
@@ -930,6 +930,23 @@ class PhocaCartControllerCheckout extends FormController
     public function order() {
 
         Session::checkToken() or jexit('Invalid Token');
+        $app_ = Factory::getApplication();
+        $msgSuffix_ = '<span id="ph-msg-ns" class="ph-hidden"></span>';
+        // Defense in depth: also block final order placement for a guest with
+        // a subscription product in the cart, in case guest status was set via
+        // 'guest_checkout_auto_enable' rather than the explicit setguest() task.
+        if (PhocacartUserGuestuser::getGuestUser()) {
+            $cart_ = new PhocacartCart();
+            $cart_->setFullItems();
+            if ($cart_->hasSubscriptionProduct()) {
+                $app_->enqueueMessage(
+                    Text::_('COM_PHOCACART_ERROR_GUEST_CHECKOUT_NOT_ALLOWED_SUBSCRIPTION') . $msgSuffix_,
+                    'error'
+                );
+                $app_->redirect(base64_decode($this->input->get('return', '', 'string')));
+                return false;
+            }
+        }
         $pC                                = PhocacartUtils::getComponentParameters();
         $display_checkout_privacy_checkbox = $pC->get('display_checkout_privacy_checkbox', 0);
         $display_checkout_toc_checkbox     = $pC->get('display_checkout_toc_checkbox', 2);
@@ -1096,6 +1113,20 @@ class PhocaCartControllerCheckout extends FormController
         $item['return'] = $this->input->get('return', '', 'string');
         $msgSuffix      = '<span id="ph-msg-ns" class="ph-hidden"></span>';
 
+           // Block enabling guest checkout if the cart contains a subscription
+        // product - a subscription must be tied to a registered user account.
+        if ((int)$item['id'] == 1) {
+            $cart = new PhocacartCart();
+            $cart->setFullItems();
+            if ($cart->hasSubscriptionProduct()) {
+                $app->enqueueMessage(
+                    Text::_('COM_PHOCACART_ERROR_GUEST_CHECKOUT_NOT_ALLOWED_SUBSCRIPTION') . $msgSuffix,
+                    'error'
+                );
+                $app->redirect(base64_decode($item['return']));
+                return false;
+            }
+        }
 
         //$guest = new PhocacartUserGuestuser();
         //$set = $guest->setGuestUser((int)$item['id']);


### PR DESCRIPTION
# Block guest checkout for subscription products

**Based on:** Phoca Cart core `6.1.3`
**Branch:** `feature/block-guest-checkout-subscription`
**Files changed:** 3
**Lines added:** 61 (no deletions, no core logic altered — purely additive)

## Problem

A subscription is tied to a registered user account (`user_id`), so guest
checkout doesn't make sense for a cart containing a subscription product.
Currently nothing prevents it: a guest can click "Continue as guest" and
place an order for a subscription product.

Testing this confirmed two consequences, not just one:

1. **UX issue** — a guest can easily miss any on-screen warning and place an
   order they can't actually use as intended.
2. **Silent data-loss bug** (in the Subscription plugin, not core) — the
   plugin's `onPhocaCartAfterOrderSave` handler currently has a guard
   `if ($row->user_id < 1) return;`, meaning if a guest order for a
   subscription product ever *does* get placed, the subscription record is
   never created — no error, no log, nothing. The customer pays and gets
   nothing. (Fixed separately in the plugin, but the real fix is preventing
   this at the source: core checkout.)

## Approach

Rather than relying on a template-only warning, block the action at the two
points in `site/controllers/checkout.php` where a guest actually moves
toward completing checkout:

- `setguest()` — the "Continue as guest" button/task. This is the primary
  block point.
- `order()` — final order placement. Added as defense-in-depth, in case
  `guest_checkout_auto_enable` sets guest status without the user ever
  hitting the `setguest` task explicitly.

**Deliberately not blocked:** viewing the checkout/cart page, changing
quantities, removing items (`checkout.update`), coupons, reward points,
currency switching. A guest can always freely browse and edit their cart —
including removing the subscription item if they change their mind — they're
only stopped from actually proceeding to checkout *with* a subscription item
still in the cart. (First version of this blocked too broadly and trapped
guests who just wanted to remove the item — fixed before finalizing this.)

## Changes

### 1. `admin/libraries/phocacart/cart/cart.php`

New method on `PhocacartCart`, added right after `getFullItems()`:

```php
/**
 * Check whether the cart currently contains at least one subscription
 * product (product type = 6).
 *
 * Used to prevent guest checkout for subscription purchases, since a
 * subscription must be tied to a registered user account.
 *
 * @return bool
 *
 * @since 6.2.0
 */
public function hasSubscriptionProduct(): bool {

    if (empty($this->fullitems[0])) {
        return false;
    }

    foreach ($this->fullitems[0] as $item) {
        // Items are stored as plain arrays (idkey => array), not objects
        if (isset($item['type']) && (int) $item['type'] === 6) {
            return true;
        }
    }

    return false;
}
```

A single shared helper instead of duplicating the check in both controller
methods.

### 2. `site/controllers/checkout.php`

**`setguest()`** — guard added at the top, before the guest flag is set:

```php
public function setguest() {

    Session::checkToken() or jexit('Invalid Token');
    $app            = Factory::getApplication();
    $item           = array();
    $item['id']     = $this->input->get('id', 0, 'int');
    $item['return'] = $this->input->get('return', '', 'string');
    $msgSuffix      = '<span id="ph-msg-ns" class="ph-hidden"></span>';

    // Block enabling guest checkout if the cart contains a subscription
    // product - a subscription must be tied to a registered user account.
    if ((int)$item['id'] == 1) {
        $cart = new PhocacartCart();
        $cart->setFullItems();
        if ($cart->hasSubscriptionProduct()) {
            $app->enqueueMessage(
                Text::_('COM_PHOCACART_ERROR_GUEST_CHECKOUT_NOT_ALLOWED_SUBSCRIPTION') . $msgSuffix,
                'error'
            );
            $app->redirect(base64_decode($item['return']));
            return false;
        }
    }

    //$guest = new PhocacartUserGuestuser();
    //$set = $guest->setGuestUser((int)$item['id']);
    $set = PhocacartUserGuestuser::setGuestUser((int)$item['id']);
    // ... unchanged from here
}
```

**`order()`** — defense-in-depth guard added right after the token check:

```php
public function order() {

    Session::checkToken() or jexit('Invalid Token');

    $app_ = Factory::getApplication();
    $msgSuffix_ = '<span id="ph-msg-ns" class="ph-hidden"></span>';
    // Defense in depth: also block final order placement for a guest with
    // a subscription product in the cart, in case guest status was set via
    // 'guest_checkout_auto_enable' rather than the explicit setguest() task.
    if (PhocacartUserGuestuser::getGuestUser()) {
        $cart_ = new PhocacartCart();
        $cart_->setFullItems();
        if ($cart_->hasSubscriptionProduct()) {
            $app_->enqueueMessage(
                Text::_('COM_PHOCACART_ERROR_GUEST_CHECKOUT_NOT_ALLOWED_SUBSCRIPTION') . $msgSuffix_,
                'error'
            );
            $app_->redirect(base64_decode($this->input->get('return', '', 'string')));
            return false;
        }
    }

    $pC = PhocacartUtils::getComponentParameters();
    // ... unchanged from here
}
```

### 3. `admin/language/en-GB/en-GB.com_phocacart.ini`

```ini
COM_PHOCACART_ERROR_GUEST_CHECKOUT_NOT_ALLOWED_SUBSCRIPTION="Your cart contains a subscription product, which requires a registered account. Please log in or register to continue, or remove the subscription item from your cart to check out as a guest."
```

## Testing done

- Guest + subscription in cart → click "Continue as guest" → blocked,
  redirected back with the error message.
- Guest + subscription in cart → view checkout page → not blocked, cart
  contents visible and editable as normal.
- Guest + subscription in cart → remove the subscription item
  (`checkout.update`) → works normally, no interference.
- Guest removes subscription item, then clicks "Continue as guest" with only
  regular products left → proceeds normally.
- Logged-in user + subscription in cart → completely unaffected, no checks
  triggered.

## Open questions for discussion

- Is `type == 6` the right long-term check, or should this instead be a
  product-level flag (e.g. `guest_checkout_disabled`) that defaults to `true`
  for subscription products but could also be set independently on other
  product types in the future?
- Would it be worth a proper dispatchable event here (e.g.
  `onPCTonBeforeGuestCheckoutEnable`, following the existing `Event\Tax\*`
  pattern) so third-party plugins can hook their own "this product requires
  an account" rules, rather than hardcoding the subscription case into core?
  Current core events in this area (e.g.
  `GuestUserAddressBeforeSaveCheckout`) are fire-and-forget notifications
  with no abort mechanism, so this would be a new pattern for the codebase
  if you want it.
